### PR TITLE
Use the default linter plus some optional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,11 +30,6 @@ linters-settings:
     suggest-new: true
   goimports:
     local-prefixes: github.com/leveeml/rabbids
-  depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/davecgh/go-spew/spew
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option
@@ -70,16 +65,15 @@ linters-settings:
     force-case-trailing-whitespace: 0
 
 linters:
-  enable-all: true
-  disable:
+  enable:
+    - goconst
+    - godot
+    - gofmt
+    - wsl
+    - unparam
+    - gocyclo
     - maligned
-    - prealloc
-    - gosec
-    - gochecknoglobals
-    - goimports
-    - gomnd
-    - goerr113
-    - testpackage
+    - misspell
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.


### PR DESCRIPTION
The golangci-lint adds more linters with some frequency.
Some of them are incompatible with others and
some make sense only in specific cases.

Instead of enabling all and block the linters a better approach is to enable
the defaults and a list of linters that make sense for this project